### PR TITLE
Add a way to mirror the directory struture when uploading a file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Required: **NO**
 
 If true, the target file name will be the complete source filename and `name` parameter will be ignored.
 
+## ``mirrorDirectoryStructure``
+Required: **NO**
+
+If true, the directory structure of the source file will be recreated relative to ``folderId``.
+
 ## ``namePrefix``
 Required: **NO**
 
@@ -90,5 +95,17 @@ jobs:
           folderId: ${{ secrets.folderId }}
           name: "documentation.zip" # optional string
           overwrite: "true" # optional boolean
+      - name: Make Directory Structure
+        run: |
+          mkdir -p w/x/y
+          date +%s > w/x/y/z
+      - name: Mirror Directory Structure
+        uses: adityak74/google-drive-upload-git-action@main
+        with:
+          credentials: ${{ secrets.DRIVE_CREDENTIALS }}
+          filename: w/x/y/z
+          folderId: ${{ secrets.folderId }}
+          overwrite: "true"
+          mirrorDirectoryStructure: "true"
           
 ```

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
   useCompleteSourceFilenameAsName:
     description: 'If true, the target file name will be the source filename and name parameter will be ignored'
     required: false
+  mirrorDirectoryStructure:
+    description: 'If true, recreate the directory structure of the source file relative to the folderId'
+    required: false
   namePrefix:
     description: 'Prefix to be added to target filename'
     required: false


### PR DESCRIPTION
This is a pretty basic version that will recreate the local paths relative to `folderId`. It won't recreate complex structures in one step but it's a start to addressing #6, It still uses `os.Glob` so it won't recurse and instead just skips directories so to fully mirror the paths, you'd need to specify each level.

